### PR TITLE
Removed unused code from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ npm i --save-dev webpack-mild-compile
 ## Webpack Plugin (作为webpack插件使用)
 
 ```JavaScript
-const compiler = webpack(webpackConfig);
 const WebpackMildCompile = require('webpack-mild-compile').Plugin;
 
 ...


### PR DESCRIPTION
The following code is not needed to use it.

```
const compiler = webpack(webpackConfig);
```