### PR TITLE
Fix: execute callback in done hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,9 @@ function timefix(compiler) {
     watching.startTime += timefix;
     callback && callback();
   };
-  const onDone = function (stats) {
+  const onDone = function (stats, callback) {
     stats.startTime -= timefix;
+    callback && callback();
   };
   const aspectWatch = compiler.watch;
   compiler.watch = function () {


### PR DESCRIPTION
The `compiler.hooks.done` hook is called as an async hook, and must
execute the provided callback function for the build to continue.